### PR TITLE
removed dataMeteor debug console log

### DIFF
--- a/vue-meteor.js
+++ b/vue-meteor.js
@@ -113,7 +113,6 @@ var VueMeteor = {
                     Vue.util.defineReactive(this, key, null)
                     this.$trackMeteor(dataMeteor[key], (function(key) {
                         return function(result) {
-                            console.log('Set ' + key + ': ' + result)
                             this[key] = result
                         }
                     })(key))


### PR DESCRIPTION
Simply removed debug `console.log()` who was polluting the console when using `dataMeteor` with lots of items.
